### PR TITLE
Wrap ObjectMapper

### DIFF
--- a/src/main/scala/org/example/sinks/ExampleDataSerializationSchema.scala
+++ b/src/main/scala/org/example/sinks/ExampleDataSerializationSchema.scala
@@ -2,23 +2,18 @@ package org.example.sinks
 
 import org.apache.flink.streaming.connectors.kafka.KafkaSerializationSchema
 import org.example.models.ExampleData
-//import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectMapper
 import java.lang
 import org.apache.kafka.clients.producer.ProducerRecord
-//import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
 class ExampleDataSerializationSchema(topic: String) extends KafkaSerializationSchema[ExampleData] {
 
-  val mapper = new ObjectMapper()
-  mapper.registerModule(DefaultScalaModule)
-
   override def serialize(element: ExampleData, timestamp: java.lang.Long): ProducerRecord[Array[Byte], Array[Byte]] = {
     val elementAsBytes: Array[Byte] =
       try {
-        mapper.writeValueAsBytes(element)
+        ObjectMapperWrapper.writeValueAsBytes(element)
       } catch {
         case e: JsonProcessingException => {
           //Array[Byte]()

--- a/src/main/scala/org/example/sinks/ObjectMapperWrapper.scala
+++ b/src/main/scala/org/example/sinks/ObjectMapperWrapper.scala
@@ -1,0 +1,18 @@
+package org.example.sinks
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+object ObjectMapperWrapper extends java.io.Serializable {
+  // this lazy is the important trick here
+  // @transient adds some safety in current Scala (see also Update section)
+  // https://stackoverflow.com/a/48385665
+  @transient lazy val mapper = {
+    val mapper = new ObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    mapper
+  }
+
+  //def readValue[T](content: String, valueType: Class[T]): T = mapper.readValue(content, valueType)
+  def writeValueAsBytes(value: Object): Array[Byte] = mapper.writeValueAsBytes(value)
+}


### PR DESCRIPTION
Wrap ObjectMapper. Although an instance of DefaultScalaModule is not serializable, the function to create an instance of DefaultScalaModule is.

https://stackoverflow.com/a/48385665

Looks like the workaround is working for this example.

```
$ bin/kafka-console-consumer.sh --topic wordcount --from-beginning --bootstrap-server localhost:9092
{"word":"to","count":1,"firstLetter":"t","timestamp":1628744754204}
{"word":"be","count":1,"firstLetter":"b","timestamp":1628744754450}
{"word":"or","count":1,"firstLetter":"o","timestamp":1628744754452}
{"word":"not","count":1,"firstLetter":"n","timestamp":1628744754452}
{"word":"to","count":2,"firstLetter":"t","timestamp":1628744754452}
{"word":"be","count":2,"firstLetter":"b","timestamp":1628744754452}
{"word":"that","count":1,"firstLetter":"t","timestamp":1628744754453}
{"word":"is","count":1,"firstLetter":"i","timestamp":1628744754453}
{"word":"the","count":1,"firstLetter":"t","timestamp":1628744754453}
{"word":"question","count":1,"firstLetter":"q","timestamp":1628744754453}
{"word":"whether","count":1,"firstLetter":"w","timestamp":1628744754453}
{"word":"tis","count":1,"firstLetter":"t","timestamp":1628744754453}
{"word":"nobler","count":1,"firstLetter":"n","timestamp":1628744754453}
{"word":"in","count":1,"firstLetter":"i","timestamp":1628744754453}
{"word":"the","count":2,"firstLetter":"t","timestamp":1628744754453}
{"word":"mind","count":1,"firstLetter":"m","timestamp":1628744754453}
{"word":"to","count":3,"firstLetter":"t","timestamp":1628744754454}
{"word":"suffer","count":1,"firstLetter":"s","timestamp":1628744754454}
{"word":"the","count":3,"firstLetter":"t","timestamp":1628744754455}
{"word":"slings","count":1,"firstLetter":"s","timestamp":1628744754455}
{"word":"and","count":1,"firstLetter":"a","timestamp":1628744754455}
{"word":"arrows","count":1,"firstLetter":"a","timestamp":1628744754455}
{"word":"of","count":1,"firstLetter":"o","timestamp":1628744754455}
{"word":"outrageous","count":1,"firstLetter":"o","timestamp":1628744754455}
{"word":"fortune","count":1,"firstLetter":"f","timestamp":1628744754455}
{"word":"or","count":2,"firstLetter":"o","timestamp":1628744754455}
{"word":"to","count":4,"firstLetter":"t","timestamp":1628744754455}
{"word":"take","count":1,"firstLetter":"t","timestamp":1628744754456}
{"word":"arms","count":1,"firstLetter":"a","timestamp":1628744754456}
{"word":"against","count":1,"firstLetter":"a","timestamp":1628744754456}
{"word":"a","count":1,"firstLetter":"a","timestamp":1628744754456}
{"word":"sea","count":1,"firstLetter":"s","timestamp":1628744754456}
{"word":"of","count":2,"firstLetter":"o","timestamp":1628744754456}
{"word":"troubles","count":1,"firstLetter":"t","timestamp":1628744754456}
^CProcessed a total of 34 messages
$
```